### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+#####################################################
+#
+# List of approvers for OpenTelemetry SIG Contributor Experience Repository
+#
+#####################################################
+#
+# Learn about membership in OpenTelemetry community:
+#  https://github.com/open-telemetry/community/blob/main/community-membership.md
+#
+#
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+#
+
+# Global owners, will be the owners for everything in the repo.
+* @open-telemetry/sig-contributor-experience-approvers


### PR DESCRIPTION
Make SIG Contributor Experience approvers code owners, so they will be asked to review when a new PR is created